### PR TITLE
update gemfile to fix security warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ gem 'wdm', '~> 0.1', platforms: [:mswin, :mingw, :x64_mingw]
 gem 'middleman-livereload'
 gem 'middleman-sprockets', '~> 4.1', '>= 4.1.1'
 gem 'builder', '~> 3.2', '>= 3.2.2'
+gem "webrick", ">= 1.8.2"
+gem 'rexml', '~> 3.2', '>= 3.2.4'
 
 source "https://rails-assets.org" do
   gem 'rails-assets-jquery'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
-    webrick (1.8.1)
+    webrick (1.9.1)
     zeitwerk (2.6.17)
 
 PLATFORMS
@@ -140,8 +140,10 @@ DEPENDENCIES
   middleman-livereload
   middleman-sprockets (~> 4.1, >= 4.1.1)
   rails-assets-jquery!
+  rexml (~> 3.2, >= 3.2.4)
   tzinfo-data
   wdm (~> 0.1)
+  webrick (>= 1.8.2)
 
 BUNDLED WITH
    2.4.22


### PR DESCRIPTION
As suggested by dependabot, updated the Gemfile to fix two critical security warnings:

- gem webrick ~> 1.8.2
- gem rexml ~> 3.2.4