### PR TITLE
increase ticker tape marquee duration

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -299,7 +299,7 @@ header {
   display: flex;
   flex: 0 0 auto;
   align-items: center;
-  animation: marquee 45s linear 0s infinite normal running;
+  animation: marquee 70s linear 0s infinite normal running;
 }
 
 .ticker-tape__text { color: #FFF; }


### PR DESCRIPTION
As requested, further increased the duration of the the ticker tape marquee to 70 seconds.